### PR TITLE
Lower PHP requirement to ^7.1; Bump GF requirement to v2.3.0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,10 @@ Gravity forms add-on for SagePay.
 
 ## Minimum Requirements
 
-- PHP v7.2
+- PHP v7.1
 - php-curl
 - WordPress v4.9.5
-- Gravity Forms v2.2.6.5
+- Gravity Forms v2.3.0.4
 
 ## Installation
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.1",
         "omnipay/sagepay": "dev-server-gift-aid"
     },
     "require-dev": {

--- a/src/MinimumRequirements.php
+++ b/src/MinimumRequirements.php
@@ -6,7 +6,7 @@ namespace Itineris\SagePay;
 
 class MinimumRequirements
 {
-    public const GRAVITY_FORMS_VERSION = '2.2.6.5';
+    public const GRAVITY_FORMS_VERSION = '2.3.0.4';
 
     public static function toArray(): array
     {
@@ -15,7 +15,7 @@ class MinimumRequirements
                 'version' => '4.9.5',
             ],
             'php' => [
-                'version' => '7.2',
+                'version' => '7.1',
                 'extensions' => [
                     'curl',
                 ],


### PR DESCRIPTION
Because [communityhospice](https://github.com/ItinerisLtd/www.communityhospice.org.uk) needs [SagePay Form Payment Gateway for Gravity Forms](https://wordpress.org/plugins/sagepay-form-payment-gateway-for-gravity-forms/) v1.1.3