### PR TITLE
Lower Gravity Forms requirment to v2.2.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Gravity forms add-on for SagePay.
 - PHP v7.1
 - php-curl
 - WordPress v4.9.5
-- Gravity Forms v2.3.0.4
+- Gravity Forms v2.2.6.1
 
 ## Installation
 

--- a/src/MinimumRequirements.php
+++ b/src/MinimumRequirements.php
@@ -6,7 +6,7 @@ namespace Itineris\SagePay;
 
 class MinimumRequirements
 {
-    public const GRAVITY_FORMS_VERSION = '2.3.0.4';
+    public const GRAVITY_FORMS_VERSION = '2.2.6.1';
 
     public static function toArray(): array
     {


### PR DESCRIPTION
Because [communityhospice](https://github.com/ItinerisLtd/www.communityhospice.org.uk) doesn't work with Gravity Forms v2.3.