### PR TITLE
Better logging

### DIFF
--- a/src/CallbackHandler.php
+++ b/src/CallbackHandler.php
@@ -30,6 +30,8 @@ class CallbackHandler
             $entry->getMeta('transaction_reference')
         );
 
+        $addOn->log_debug(__METHOD__ . '(): After accepting notification');
+
         // Get the response message ready for returning.
         /* @var ServerNotifyResponse $response */ // phpcs:ignore
         $response = $request->send();
@@ -43,6 +45,8 @@ class CallbackHandler
             'final_transaction_reference',
             $response->getTransactionReference()
         );
+
+        $addOn->log_debug(__METHOD__ . '(): Final transaction reference saved');
 
         $feed = self::getFeedByEntry($entry, $response, $addOn);
 

--- a/src/RedirectUrlFactory.php
+++ b/src/RedirectUrlFactory.php
@@ -40,7 +40,7 @@ class RedirectUrlFactory
         // Note that at this point `transactionReference` is not yet complete for the Server transaction,
         // but must be saved in the database for the notification handler to use.
         $entry->setMeta('transaction_reference', $response->getTransactionReference());
-        $addOn->log_debug(__METHOD__ . '(): Set transaction reference to ' . $entry->getMeta('transaction_reference'));
+        $addOn->log_debug(__METHOD__ . '(): Transaction reference saved');
 
         if (! $response->isRedirect()) {
             self::handleFailure($response, $entry, $addOn);
@@ -55,12 +55,18 @@ class RedirectUrlFactory
 
     private static function getNotifyUrl(GFPaymentAddOn $addOn, Feed $feed): string
     {
+        $callback = $addOn->get_slug();
+        $vendor = $feed->getVendor();
+        $isTest = $feed->isTest() ? 'true' : 'false';
+
+        $addOn->log_debug(__METHOD__ . '(): Callback - ' . $callback . ' Vendor - ' . $vendor . ' $isTest - ' . $isTest);
+
         return esc_url_raw(
             add_query_arg(
                 [
-                    'callback' => $addOn->get_slug(),
-                    'vendor' => $feed->getVendor(),
-                    'isTest' => $feed->isTest() ? 'true' : 'false',
+                    'callback' => $callback,
+                    'vendor' => $vendor,
+                    'isTest' => $isTest,
                 ],
                 home_url()
             )


### PR DESCRIPTION
- log life cycle events
- hide `transaction reference`
- log SagePay checkout URL params