### PR TITLE
Add extra query param to confirmation URL

### DIFF
--- a/src/ConfirmationHandler.php
+++ b/src/ConfirmationHandler.php
@@ -127,6 +127,7 @@ class ConfirmationHandler
                 [
                     'entry' => $entry->getId(),
                     'gf-sagepay-token' => $confirmationToken,
+                    'extra' => 'protection',
                 ],
                 $entry->getProperty('source_url')
             )


### PR DESCRIPTION
To protected faulty plugins from adding extra chars to the end of confirmation URL which makes `ConfirmationHandler::maybeContinue` early quit.