### PR TITLE
Update `Plugin URI` to GitHub repo URL

### DIFF
--- a/gf-sagepay.php
+++ b/gf-sagepay.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name:     GF SagePay
- * Plugin URI:      https://www.itineris.co.uk/
+ * Plugin URI:      https://github.com/ItinerisLtd/gf-sagepay
  * Description:     SagePay payment gateway for Gravity Forms
  * Version:         0.10.3
  * Author:          Itineris Limited


### PR DESCRIPTION
Fix wp.org plugini validation error:
```
Error: Your plugin and author URIs are the same. A plugin URI (Uniform Resource Identifier) is a webpage that provides details about this specific plugin. An author URI is a webpage that provides information about the author of the plugin. Those two URIs must be different. You are not required to provide both, so pick the one that best applies to your situation.
```